### PR TITLE
add locale information for using UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:7.10.0
 MAINTAINER Jeff Dickey <jeff@heroku.com>
 
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
 RUN apt-get -y update && \
   apt-get install -y --no-install-recommends \
   apt-utils \
@@ -8,8 +9,14 @@ RUN apt-get -y update && \
   ruby ruby-dev \
   python-pip python-dev build-essential \
   p7zip-full \
+  locales \
   && apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+RUN locale-gen
 
 RUN pip install --upgrade pip && \
       pip install --upgrade virtualenv && \


### PR DESCRIPTION
The devcenter gem kept throwing errors due to invalid characters.
This is because the environment was set to run in us ascii encoding.
To resolve this I needed to install some locale tools and make
the shell environment use en_US.UTF-8